### PR TITLE
Fix name error during shutdown

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -397,7 +397,7 @@ class ReminderSkill(MycroftSkill):
             return False
 
     def shutdown(self):
-        if isinstance(self.bus, WebsocketClient):
+        if isinstance(self.bus, MessageBusClient):
             self.bus.remove('speak', self.prime)
             self.bus.remove('mycroft.skill.handler.complete', self.notify)
             self.bus.remove('mycroft.skill.handler.start', self.reset)


### PR DESCRIPTION
Skill would raise a NameError during shutdown due to a reference to the old WebsocketClient name being used. 