### PR TITLE
en: make reminder vocab more flexible

### DIFF
--- a/vocab/en-us/ReminderAt.intent
+++ b/vocab/en-us/ReminderAt.intent
@@ -1,7 +1,8 @@
-(remind|notify) me to {reminder} ((at|on) {timedate}|tomorrow|the day after {date})
-add new reminder {reminder} (at|on) {timedate}
-add a reminder to {reminder} (at|on) {timedate}
-(remind|notify) me about {reminder} (at|on) {timedate}
+(remind|notify) me to {reminder} ((at|on|for) {timedate}|tomorrow|the day after {date})
+(add|set) new reminder {reminder} (at|on|for) {timedate}
+(add|set) a reminder to {reminder} (at|on|for) {timedate}
+(add|set) a reminder (at|on|for) {timedate} to {reminder}
+(remind|notify) me about {reminder} (at|on|for) {timedate}
 (remind|notify) me to {reminder} in {timedate}
 add new reminder {reminder} in {timedate}
 add a reminder to {reminder} in {timedate}


### PR DESCRIPTION
#### Description

Make reminder vocab more flexible. After the first time we kept forgetting the exact syntax to add a reminder.
Those are the variants we use in our household.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing

works better

#### Documentation

-

#### CLA

signed